### PR TITLE
Handle filtering by name and minor exceptions

### DIFF
--- a/docs/sabre1041.eda.k8s_source_plugin.rst
+++ b/docs/sabre1041.eda.k8s_source_plugin.rst
@@ -138,6 +138,22 @@ Parameters
             <tr>
                 <td colspan="3">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>field_selector</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">list</span>
+                         / <span style="color: purple">elements=string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Selector (field query) to filter on.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="3">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>host</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -4,7 +4,7 @@ namespace: sabre1041
 
 name: eda
 
-version: 1.0.0
+version: 1.0.1
 
 readme: README.md
 

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,2 @@
 ---
-requires_ansible: '>=2.11'
+requires_ansible: ">=2.13.0"


### PR DESCRIPTION
hi @sabre1041, first of all thank you for your effort, with this PR I would like to address some issues I faced:

- There's a failure when using "name" as a parameter due to python kubernetes-client returning a named object [1]. Unfortunately the PR with the fix is not yet merged, so I introduced the following changes:

[v] Add the name as a field_selector, appending it if there are other selectors.
[v] Since the "name" parameter is handled differently, I removed it from the list when enriching the client options

- Wrapped the event loop in a try/catch to handle generic connectivity exceptions (API server unavailability, etc) to avoid the rulebook to exit

- Added the field_selectors documentation in the README

Now the flow is smooth,  I tested it the whole morning with different combinations and kept it running, and it's still working like a charm.

Hope this is useful,
Ale

[1] https://github.com/kubernetes-client/python/pull/2076